### PR TITLE
update examples for  usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,15 +92,15 @@ COPY pubspec.* .
 RUN dart pub get
 COPY . .
 RUN dart pub get --offline
-RUN dart compile kernel -o bin/server.snapshot bin/server.dart
+RUN dart compile kernel -o bin/server.dill bin/server.dart
 
 FROM subfuzion/dart-scratch
 COPY --from=0 /usr/lib/dart/bin/dart /usr/lib/dart/bin/dart
-COPY --from=0 /app/bin/server.snapshot /app/bin/server.snapshot
+COPY --from=0 /app/bin/server.dill /app/bin/server.dill
 # COPY any other directories or files you may require at runtime, ex:
 #COPY --from=0 /app/static/ /app/static/
 EXPOSE 8080
-ENTRYPOINT ["/usr/lib/dart/bin/dart", "/app/bin/server.snapshot"]
+ENTRYPOINT ["/usr/lib/dart/bin/dart", "/app/bin/server.dill"]
 ```
 
 ---

--- a/examples/dart-aot/Dockerfile
+++ b/examples/dart-aot/Dockerfile
@@ -3,8 +3,8 @@ WORKDIR /app
 COPY pubspec.* .
 RUN pub get
 COPY . .
-RUN pub get --offline
-RUN dart2native /app/bin/server.dart -o /app/bin/server
+RUN dart pub get --offline
+RUN dart compile exe /app/bin/server.dart -o /app/bin/server
 
 FROM subfuzion/dart-scratch
 COPY --from=0 /app/bin/server /app/bin/server

--- a/examples/dart-vm/Dockerfile
+++ b/examples/dart-vm/Dockerfile
@@ -3,11 +3,11 @@ WORKDIR /app
 COPY pubspec.* .
 RUN pub get
 COPY . .
-RUN pub get --offline
-RUN dart --snapshot=bin/server.snapshot bin/server.dart
+RUN dart pub get --offline
+RUN dart compile kernel -o bin/server.dill bin/server.dart
 
 FROM subfuzion/dart-scratch
 COPY --from=0 /usr/lib/dart/bin/dart /usr/lib/dart/bin/dart
-COPY --from=0 /app/bin/server.snapshot /app/bin/server.snapshot
+COPY --from=0 /app/bin/server.dill /app/bin/server.dill
 EXPOSE 8080
-ENTRYPOINT ["/usr/lib/dart/bin/dart", "/app/bin/server.snapshot"]
+ENTRYPOINT ["/usr/lib/dart/bin/dart", "/app/bin/server.dill"]


### PR DESCRIPTION
Use the new `dart compile exe|kernel` commands in the Dockerfile examples.