### PR TITLE
fixes #6 - add certs for https requests to remote hosts

### DIFF
--- a/2.12-dev/Dockerfile
+++ b/2.12-dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/dart AS dart
+FROM google/dart:2.12.0-33.0.dev AS dart
 
 FROM scratch
 # Absolute minimum

--- a/test/bin/server.dart
+++ b/test/bin/server.dart
@@ -38,6 +38,20 @@ void main(List<String> args) async {
     return shelf.Response.ok('ok');
   });
 
+  app.get('/client-certs-test', (shelf.Request req) async {
+    const url = 'https://dart.dev';
+    try {
+      var resp = await http.read(url);
+      if (resp.startsWith('<!DOCTYPE html>')) {
+        return shelf.Response.ok('ok');
+      } else {
+        return shelf.Response.internalServerError(body: resp);
+      }
+    } catch (e) {
+      return shelf.Response.internalServerError(body: e.toString());
+    }
+  });
+
   var server = await io.serve(app.handler, host, port);
   print('Serving at http://${server.address.host}:${server.port}');
 }

--- a/test/dartslim_test.sh
+++ b/test/dartslim_test.sh
@@ -19,11 +19,20 @@ function check {
   (($? != 0)) && error "$1"
 }
 
+echo "Building local image: subfuzion/dart:slim..."
+docker build -t subfuzion/dart:slim ..
+check "unable to build subfuzion/dart:slim"
+docker image ls subfuzion/dart:slim
+
+echo "Building local test image: $image..."
 docker build -t "$image" .
-check "unable to build image"
+check "unable to build test image"
+docker image ls $image
 
+echo "Starting server in test container..."
 docker run -d -p 8080:8080 --name "$ctr" "$image"
-check "unable to start a test container from image: $image"
+check "unable to start a test container from test image: $image"
+echo "Started test server"
 
+echo "Starting tests..."
 dart test -r expanded
-

--- a/test/test/image_test.dart
+++ b/test/test/image_test.dart
@@ -27,9 +27,17 @@ void main() {
     });
   });
 
-  group('Server DNS client tests', () {
+  group('Server - DNS client tests', () {
     test('remote-ping-test', () async {
       var url = serverUrl.replace(path: '/remote-ping-test');
+      var resp = await http.read(url);
+      expect(resp, equals('ok'));
+    });
+  });
+
+  group('Server - TLS client cert tests', () {
+    test('client-certs-test', () async {
+      var url = serverUrl.replace(path: '/client-certs-test');
       var resp = await http.read(url);
       expect(resp, equals('ok'));
     });


### PR DESCRIPTION
Copies `/usr/share/ca-certificates` and `/etc/ssl/certs` from `google/dart` base image.
Adds a new test to verify client `https` requests succeed.

To test, run `dartslim_test.sh` from inside the `test` directory (requires Docker and Dart).